### PR TITLE
fix cmake and update sc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 os: osx
-osx_image: xcode7.3
+osx_image: xcode10.1
 cache: ccache
 before_install:
  - $TRAVIS_BUILD_DIR/supercollider/.travis/before-install-osx.sh --qt=true
@@ -8,7 +8,7 @@ before_script:
  - mkdir $TRAVIS_BUILD_DIR/supercollider/BUILD
  - mkdir $TRAVIS_BUILD_DIR/BUILD
  - cd $TRAVIS_BUILD_DIR/supercollider/BUILD
- - cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt55`  ..
+ - cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt5`  ..
 script:
  - cmake --build $TRAVIS_BUILD_DIR/supercollider/BUILD --target install --config RelWithDebInfo
  - cd $TRAVIS_BUILD_DIR/BUILD

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
  - cmake ..
  - make
  - cp -r $TRAVIS_BUILD_DIR/BUILD/SuperColliderAU.component ~/Library/Audio/Plug-Ins/Components/SuperColliderAU.component
- - auval -v aumf SCAU SCAU -r 4
+ - auval -v aumf SCAU SCAU -r 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
  - cd $TRAVIS_BUILD_DIR/supercollider/BUILD
  - cmake -G Xcode -DCMAKE_PREFIX_PATH=`brew --prefix qt5`  ..
 script:
- - cmake --build $TRAVIS_BUILD_DIR/supercollider/BUILD --target install --config RelWithDebInfo
+ - cmake --build $TRAVIS_BUILD_DIR/supercollider/BUILD --target install --config RelWithDebInfo -- -quiet
  - cd $TRAVIS_BUILD_DIR/BUILD
  - cmake ..
  - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.11) # needed for CFBundle building
+project(SuperColliderAU)
 
 if(NOT APPLE)
 	message(SEND_ERROR "ERROR: only APPLE platform is supported")
@@ -29,16 +30,13 @@ endif()
 
 file(GLOB PLUGINS ${SC_DIR}/build/server/plugins/${CMAKE_BUILD_TYPE}/*.scx)
 
+set(CMAKE_MODULE_PATH ${SC_DIR}/cmake_modules)
 include (${SC_DIR}/cmake_modules/FinalFile.cmake)
 include (${SC_DIR}/cmake_modules/FindPthreads.cmake)
 include (${SC_DIR}/cmake_modules/FindSndfile.cmake)
 
 find_package(Pthreads)
 find_package(Sndfile)
-
-if (NOT PTHREADS_FOUND)
-		message(SEND_ERROR "cannot find libpthreads")
-endif()
 
 if (NOT PTHREADS_FOUND)
 		message(SEND_ERROR "cannot find libpthreads")
@@ -75,12 +73,12 @@ set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -stdlib=libc++")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
 set(scau_bundle "SuperColliderAU")
-set(SNDFILE_INCLUDE_DIR ${SC_DIR}/external_libraries/libsndfile/)
-set(BOOST_INCLUDE_DIR ${SC_DIR}external_libraries/boost/)
-set(TLSF_INCLUDE_DIR ${SC_DIR}/external_libraries/TLSF-2.4.6/src/)
+set(SNDFILE_INCLUDE_DIR ${SC_DIR}/external_libraries/libsndfile)
+set(BOOST_INCLUDE_DIR ${SC_DIR}/external_libraries/boost)
+set(TLSF_INCLUDE_DIR ${SC_DIR}/external_libraries/TLSF-2.4.6/src)
 
 include_directories(${SC_DIR}/external_libraries
-	${SC_DIR}/${BOOST_INCLUDE_DIR}
+	${BOOST_INCLUDE_DIR}
 	${SNDFILE_INCLUDE_DIR}
 	${PTHREADS_INCLUDE_DIR}
 	${TLSF_INCLUDE_DIR}
@@ -115,8 +113,8 @@ add_definitions("-D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0")
 add_definitions(-w)# TODO: fix deprecation warnings
 
 if (NOT Boost_FOUND)
-	file(GLOB boost_system_sources ../../external_libraries/boost/libs/system/src/*cpp)
-	file(GLOB boost_filesystem_sources ../../external_libraries/boost/libs/filesystem/src/*cpp)
+	file(GLOB boost_system_sources ${SC_DIR}/external_libraries/boost/libs/system/src/*cpp)
+	file(GLOB boost_filesystem_sources ${SC_DIR}/external_libraries/boost/libs/filesystem/src/*cpp)
 endif()
 
 set(scau_sources
@@ -251,7 +249,7 @@ add_definitions("-DLIBSNDFILE_1018")
 if (Boost_FOUND)
 	target_link_libraries(${scau_bundle} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} )
 else()
-	target_link_libraries(${scau_bundle} boost_system boost_filesystem)
+	target_link_libraries(${scau_bundle} boost_system_lib boost_filesystem_lib)
 endif()
 
 target_link_libraries(${scau_bundle} ${PTHREADS_LIBRARY})

--- a/Source/SuperColliderAU.cpp
+++ b/Source/SuperColliderAU.cpp
@@ -20,7 +20,7 @@
 
 
 
-AUDIOCOMPONENT_ENTRY(AUBaseFactory, SuperColliderAU)
+AUDIOCOMPONENT_ENTRY(AUMIDIEffectFactory, SuperColliderAU)
 
 SuperColliderAU::SuperColliderAU(AudioUnit component)
         : AUMIDIEffectBase(component)

--- a/Source/SuperColliderAU.cpp
+++ b/Source/SuperColliderAU.cpp
@@ -198,7 +198,7 @@ ComponentResult SuperColliderAU::Initialize()
       scprintf("*******************************************************\n");
       scprintf("SuperColliderAU Initialized \n");
 	    scprintf("SuperColliderAU provided under the GNU GPL license. http://www.gnu.org/licenses/gpl-2.0.txt \n");
-	    scprintf("SuperColliderAU source code: http://supercollider.sf.net \n");
+	    scprintf("SuperColliderAU source code: https://github.com/supercollider/SuperColliderAU \n");
       scprintf("SuperColliderAU mPreferredHardwareBufferFrameSize: %d \n",options.mPreferredHardwareBufferFrameSize );
       scprintf("SuperColliderAU mBufLength: %d \n",options.mBufLength );
       scprintf("SuperColliderAU  port: %d \n", superCollider->portNum );


### PR DESCRIPTION
I've updated SC sources and made changes to CMake to make SuperColliderAU build. Fixes #4, and #7, supersedes #8.

Aside from CMake updates, I made one change to the source, that fixed the error from `auval`:
```
Test MIDI
ERROR: -4 IN CALL MusicDeviceMIDIEvent
```

`auval` now passes, but only for no more than two runs of the plugin (`-r 2`). I'd like to file this as a separate issue later.