### PR TITLE
Set number of input/output channels from the host

### DIFF
--- a/Source/SuperColliderAU.cpp
+++ b/Source/SuperColliderAU.cpp
@@ -144,6 +144,8 @@ ComponentResult SuperColliderAU::Initialize()
 	  options.mMaxWireBufs = kDefaultNumWireBufs;
     options.mRealTimeMemorySize = kDefaultRtMemorySize;
     options.mNumBuffers = 8192;
+    options.mNumInputBusChannels = GetNumberOfChannels();
+    options.mNumOutputBusChannels = GetNumberOfChannels();
 
     CFStringRef pluginsPath = resources->getResourcePath(resources->SC_PLUGIN_PATH);
     CFStringRef synthdefsPath = resources->getResourcePath(resources->SC_SYNTHDEF_PATH);


### PR DESCRIPTION
This addition, as far as I can tell, makes SCAU to start with the number of channels set by the host. Previously this value was set to 8 (default in SuperCollider's WorldOptions).